### PR TITLE
added cli switches as env args for port and auth provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ FROM alpine
 COPY --from=golang /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=golang /go/bin/mantle /app/mantle
 
-EXPOSE 8000
 VOLUME /root/.config/mantle
-CMD ["/app/mantle"]
+CMD /app/mantle \
+  --port ${PORT:-8000} \
+  --auth-${AUTH:-discord}-id $(cat /run/secrets/MANTLE_AUTH_CLIENT_ID) \
+  --auth-${AUTH:-discord}-secret $(cat /run/secrets/MANTLE_AUTH_CLIENT_SECRET)


### PR DESCRIPTION
- New secrets:
  + `MANTLE_AUTH_CLIENT_ID` client_id of oauth provider
  + `MANTLE_AUTH_CLIENT_SECRET` client_secret of oauth provider
- New envs:
  + `PORT` port which mantle will bind to
  + `AUTH` short code of auth provider as defined by [nektro/go.oauth2](https://github.com/nektro/go.oauth2)

```shell
$ cat docker-compose.yml
version: "3.1"
services:
  mantle:
    build:
      context: ./mantle
      dockerfile: ./.docker/Dockerfile
    secrets:
      - MANTLE_AUTH_CLIENT_ID
      - MANTLE_AUTH_CLIENT_SECRET
    ports:
      - 80
    environment:
      - PORT=80
      - AUTH=discord
    volumes:
      - ./mantle/config:/root/.config/mantle

secrets:
  MANTLE_AUTH_CLIENT_ID:
    file: ./mantle/secrets/client_id
  MANTLE_AUTH_CLIENT_SECRET:
    file: ./mantle/secrets/client_secret
```

```shell
$ tree -p mantle/
mantle/
├── [drwxr-sr-x]  config
└── [drwxr-sr-x]  secrets
    ├── [-rw-r--r--]  client_id
    └── [-rw-r--r--]  client_secret
```